### PR TITLE
Fix box.m shebang

### DIFF
--- a/miralib/ex/box.m
+++ b/miralib/ex/box.m
@@ -1,4 +1,4 @@
-#! /home/dat/mira/states/src/miranda/mira -exec
+#!/usr/bin/env -S mira -exec
 || Contributed by John Cupitt, University of Kent
 
 ||A while ago Steve Hill (I think) appealed for useful Miranda programs


### PR DESCRIPTION
File was distributed with `/home/dat` as path. Updated to use `/usr/bin/env -S`.